### PR TITLE
WIP BXMSDOC-5425: Added example for DMNRuntimeListener property as part of kmodule.xml

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-properties-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-properties-ref.adoc
@@ -43,6 +43,7 @@ org.kie.dmn.profiles.$PROFILE_NAME::
 When valorized with a Java fully qualified name, this property loads a DMN profile onto the {DECISION_ENGINE} at start time. You can use this property to implement a predefined DMN profile with supported features different from or beyond the DMN standard. For example, if you are creating DMN models using the Signavio DMN modeller, use this property to implement features from the Signavio DMN profile into your DMN decision service.
 +
 --
+[source]
 ----
 -Dorg.kie.dmn.profiles.signavio=org.kie.dmn.signavio.KieDMNSignavioProfile
 ----
@@ -54,6 +55,7 @@ When valorized with a Java fully qualified name, this property loads and registe
 You can use this property to register a DMN listener in order to be notified of several events during DMN model evaluations.
 +
 --
+[source]
 ----
 -Dorg.kie.dmn.runtime.listeners.mylistener=org.acme.MyDMNListener
 ----
@@ -63,6 +65,7 @@ You can use this property to register a DMN listener in order to be notified of 
 You can also configure this property in the `kmodule.xml` file in your project.
 +
 --
+[source,xml]
 ----
 <kmodule xmlns="http://www.drools.org/xsd/kmodule">
   <configuration>
@@ -70,7 +73,6 @@ You can also configure this property in the `kmodule.xml` file in your project.
   </configuration>
 </kmodule>
 ----
-//kept removed `[source]` for this last snippet because it rendered unlike all the others in community output otherwise for some reason. as per SJR comment above.
 --
 
 org.kie.dmn.compiler.execmodel::

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-properties-ref.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-properties-ref.adoc
@@ -52,11 +52,23 @@ When valorized with a Java fully qualified name, this property loads a DMN profi
 org.kie.dmn.runtime.listeners.$LISTENER_NAME::
 When valorized with a Java fully qualified name, this property loads and registers a DMN Runtime Listener onto the {DECISION_ENGINE} at start time.
 You can use this property to register a DMN listener in order to be notified of several events during DMN model evaluations.
-You can also configure this property in the `kmodule.xml` file in your project.
 +
 --
 ----
 -Dorg.kie.dmn.runtime.listeners.mylistener=org.acme.MyDMNListener
+----
+//kept removed `[source]` for this last snippet because it rendered unlike all the others in community output otherwise for some reason. as per SJR comment above.
+--
++
+You can also configure this property in the `kmodule.xml` file in your project.
++
+--
+----
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <configuration>
+    <property key="org.kie.dmn.runtime.listeners.mylistener" value="org.acme.MyDMNListener"/>
+  </configuration>
+</kmodule>
 ----
 //kept removed `[source]` for this last snippet because it rendered unlike all the others in community output otherwise for some reason. as per SJR comment above.
 --


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-5425

Rendered output:
[Designing a decision service using DMN models RHPAM](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5425-RHPAM/#dmn-properties-ref_dmn-models)
[Designing a decision service using DMN models RHDM](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-5425-RHDM/#dmn-properties-ref_dmn-models)