### PR TITLE
WIP BXMSDOC-7136: Added a note for VSCode incompatibility with Business central

### DIFF
--- a/assemblies/assembly-designing-business-processes.adoc
+++ b/assemblies/assembly-designing-business-processes.adoc
@@ -21,6 +21,8 @@ include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
 include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
+include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
+
 include::{enterprise-dir}/bpmn/bpmn-con.adoc[leveloffset=+1]
 include::{enterprise-dir}/bpmn/bpmn-support-con.adoc[leveloffset=+2]
 include::{jbpm-dir}/BPMN2/bpmn-events-con.adoc[leveloffset=+2]

--- a/assemblies/assembly-dmn-models.adoc
+++ b/assemblies/assembly-dmn-models.adoc
@@ -20,6 +20,8 @@ include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
 include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
+include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
+
 include::{drools-dir}/DMN/dmn-con.adoc[leveloffset=+1]
 
 include::{drools-dir}/DMN/dmn-conformance-levels-con.adoc[leveloffset=+2]

--- a/assemblies/assembly-getting-started-decision-services.adoc
+++ b/assemblies/assembly-getting-started-decision-services.adoc
@@ -24,6 +24,8 @@ include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
 include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
+include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
+
 include::{drools-dir}/DMN/dmn-gs-new-project-creating-proc.adoc[leveloffset=+1]
 
 include::{drools-dir}/DMN/dmn-con.adoc[leveloffset=+1]

--- a/assemblies/assembly-getting-started-process-services.adoc
+++ b/assemblies/assembly-getting-started-process-services.adoc
@@ -27,6 +27,8 @@ include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
 include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
+include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
+
 include::{enterprise-dir}/getting-started/new-project-proc.adoc[leveloffset=+1]
 
 include::{enterprise-dir}/getting-started/creating-users-proc.adoc[leveloffset=+1]

--- a/doc-content/drools-docs/src/main/asciidoc/DMN-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN-chapter.adoc
@@ -6,6 +6,8 @@ include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
 include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
+include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
+
 include::DMN/dmn-con.adoc[leveloffset=+1]
 
 include::DMN/dmn-conformance-levels-con.adoc[leveloffset=+2]

--- a/doc-content/drools-docs/src/main/asciidoc/DMN-chapter.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN-chapter.adoc
@@ -2,12 +2,6 @@
 = Decision Model and Notation (DMN)
 :context: dmn-models
 
-include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
-include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
-include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
-
-include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
-
 include::DMN/dmn-con.adoc[leveloffset=+1]
 
 include::DMN/dmn-conformance-levels-con.adoc[leveloffset=+2]

--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-new-project-creating-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-gs-new-project-creating-proc.adoc
@@ -1,5 +1,5 @@
 [id='dmn-gs-new-project-creating-proc']
-= Creating the traffic violations project
+= Creating the traffic violations project in {CENTRAL}
 
 For this example, create a new project called `traffic-violation`. A project is a container for assets such as data objects, DMN assets, and test scenarios. This example project that you are creating is similar to the existing *Traffic_Violation* sample project in {CENTRAL}.
 

--- a/doc-content/enterprise-only/getting-started/new-project-ds-proc.adoc
+++ b/doc-content/enterprise-only/getting-started/new-project-ds-proc.adoc
@@ -1,5 +1,5 @@
 [id='decision-services-project-create-proc']
-= Creating the traffic violations project
+= Creating the traffic violations project in {CENTRAL}
 A project is a container for assets such as data objects, guided decision tables, and guided rules.
 
 

--- a/doc-content/enterprise-only/getting-started/new-project-proc.adoc
+++ b/doc-content/enterprise-only/getting-started/new-project-proc.adoc
@@ -1,5 +1,5 @@
 [id='creating_business_project']
-= Creating the mortgage-process project
+= Creating the mortgage-process project in {CENTRAL}
 
 A project is a container for assets such as data objects, business processes, guided rules, decision tables, and forms. The project that you are creating is similar to the existing *Mortgage_Process* sample project in {CENTRAL}.
 

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/Process-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/Process-section.adoc
@@ -7,6 +7,8 @@ include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
 include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
 include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
 
+include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
+
 include::design-business-process-proc.adoc[leveloffset=+1]
 
 //include::create-task-proc.adoc[leveloffset=+2]

--- a/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/Process-section.adoc
+++ b/doc-content/jbpm-docs/src/main/asciidoc/BPMN2/Process-section.adoc
@@ -3,12 +3,6 @@
 
 include::business-process-overview-con.adoc[]
 
-include::{shared-dir}/Install/con-BPMN-DMN-modelers.adoc[leveloffset=+1]
-include::{shared-dir}/Install/proc-vscode-extension.adoc[leveloffset=+2]
-include::{shared-dir}/Install/proc-standalone-editors.adoc[leveloffset=+2]
-
-include::{shared-dir}/Install/proc-dmn-bpmn-maven-create.adoc[leveloffset=+1]
-
 include::design-business-process-proc.adoc[leveloffset=+1]
 
 //include::create-task-proc.adoc[leveloffset=+2]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
@@ -1,7 +1,7 @@
 [id="proc-dmn-bpmn-maven-create_{context}"]
 = Creating and executing DMN and BPMN models using Maven
 
-You can use Maven archetypes to develop DMN and BPMN models and integrate the archetypes with your {PRODUCT} decision and process services. This method of developing DMN and BPMN models is helpful for building new business applications using the {PRODUCT} VSCode extension.
+You can use Maven archetypes to develop DMN and BPMN models in VSCode using the {PRODUCT} VSCode extension instead of {CENTRAL}. You can then integrate your archetypes with your {PRODUCT} decision and process services in {CENTRAL} as needed. This method of developing DMN and BPMN models is helpful for building new business applications using the {PRODUCT} VSCode extension.
 
 .Procedure
 . In a command terminal, navigate to a local folder where you want to store the new {PRODUCT} project.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
@@ -1,0 +1,51 @@
+[id="proc-dmn-bpmn-maven-create_{context}"]
+= Creating and executing DMN and BPMN models using Maven
+
+You can use Maven archetypes to develop DMN and BPMN models and integrate the archetypes with your {PRODUCT} decision and process services. This method of developing DMN and BPMN models is helpful for building new business applications using the {PRODUCT} VSCode extension.
+
+.Procedure
+. In a command terminal, navigate to a local folder where you want to store the new {PRODUCT} project.
+. Enter the following command to generate a project within a defined folder using the default Maven archetype:
++
+ifdef::PAM,DM[]
+.Generating a project using Maven archetype
+[source]
+----
+mvn archetype:generate \
+    -DarchetypeGroupId=org.kie \
+    -DarchetypeArtifactId=kie-kjar-archetype \
+    -DarchetypeVersion={rhpam.version}-SNAPSHOT
+----
+endif::PAM,DM[]
+
+ifdef::DROOLS,JBPM,OP[]
+.Generating a project using Maven archetype
+[source]
+----
+mvn archetype:generate \
+    -DarchetypeGroupId=org.kie \
+    -DarchetypeArtifactId=kie-kjar-archetype \
+    -DarchetypeVersion={drools.version}-SNAPSHOT
+----
+endif::DROOLS,JBPM,OP[]
+
++
+This command generates a Maven project and imports the {PRODUCT} VSCode extension for all required dependencies and configurations to prepare your application for business automation.
++
+If you want to create more than one project, then add `-DgroupId=<groupid> -DartifactId=<artifactId>` to the previous command.
+
+. Open or import the project in your VSCode IDE to edit existing assets or create new assets.
+. After you create and save the assets in your Maven archetype, navigate to the Maven project directory in the command line and run the following command to build your files:
++
+.Building Maven project
+[source]
+----
+mvn clean install
+----
++
+If the build fails, address any problems described in the command line error messages and try again to validate the files until the build is successful.
++
+After the build is successful, compile the Maven project as a knowledge JAR (KJAR) and deploy the artifacts on a running {KIE_SERVER} using the REST API.
+ifdef::DM,PAM[]
+For more information about using REST API, see {URL_DEPLOYING_AND_MANAGING_SERVICES}#assembly-kie-apis[_{KIE_APIS}_].
+endif::DM,PAM[]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
@@ -5,7 +5,7 @@ You can use Maven archetypes to develop DMN and BPMN models in VSCode using the 
 
 .Procedure
 . In a command terminal, navigate to a local folder where you want to store the new {PRODUCT} project.
-. Enter the following command to generate a project within a defined folder using the default Maven archetype:
+. Enter the following command to generate a project within a defined folder using the following Maven archetype:
 +
 ifdef::PAM,DM[]
 .Generating a project using Maven archetype
@@ -14,7 +14,7 @@ ifdef::PAM,DM[]
 mvn archetype:generate \
     -DarchetypeGroupId=org.kie \
     -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion={ENTERPRISE_VERSION_LONG}-SNAPSHOT
+    -DarchetypeVersion={ENTERPRISE_VERSION_LONG}
 ----
 endif::PAM,DM[]
 
@@ -25,17 +25,25 @@ ifdef::DROOLS,JBPM,OP[]
 mvn archetype:generate \
     -DarchetypeGroupId=org.kie \
     -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion={COMMUNITY_VERSION_LONG}-SNAPSHOT
+    -DarchetypeVersion={COMMUNITY_VERSION_LONG}
 ----
 endif::DROOLS,JBPM,OP[]
 
 +
-This command generates a Maven project and imports the {PRODUCT} VSCode extension for all required dependencies and configurations to prepare your application for business automation.
+This command generates a Maven project with required dependencies and generates required directories and files to build your business application. You can set up and use Git version-control system (recommended) when developing a project.
 +
-If you want to create more than one project, then add `-DgroupId=<groupid> -DartifactId=<artifactId>` to the previous command.
+If you want to generate multiple projects in the same directory, you can specify the `artifactId` and `groupId` of the generated business application by adding `-DgroupId=<groupid> -DartifactId=<artifactId>` to the previous command.
 
-. Open or import the project in your VSCode IDE to edit existing assets or create new assets.
-. After you create and save the assets in your Maven archetype, navigate to the Maven project directory in the command line and run the following command to build your files:
+. In your VSCode IDE, click *File*, select *Open Folder*, and navigate to the folder that is generated using the previous command.
++
+. Before creating the first asset, set a package for your business application, for example, `org.kie.businessapp`.
+. Create a Java object in `src/main/java/` directory, for example, `/src/main/java/org/kie/businessapp/DataObject.java`.
+. Create your business process or business rules in `src/main/resources` directory, for example, `/src/main/resources/org/kie/businessapp/Process.bpmn`.
+
++
+You can use VSCode to create files and folders as per your requirement.
+
+. After you create the assets in your Maven archetype, navigate to the project directory (contains `pom.xml`) in the command line and run the following command to build your files:
 +
 .Building Maven project
 [source]
@@ -43,9 +51,9 @@ If you want to create more than one project, then add `-DgroupId=<groupid> -Dart
 mvn clean install
 ----
 +
-If the build fails, address any problems described in the command line error messages and try again to validate the files until the build is successful.
+If the build fails, address any problems described in the command line error messages and try again to validate the project until the build is successful.
 +
-After the build is successful, compile the Maven project as a knowledge JAR (KJAR) and deploy the artifacts on a running {KIE_SERVER} using the REST API.
+After the build is successful, you can deploy the generated knowledge JAR (KJAR) of your business application on a running {KIE_SERVER} using the REST API.
 ifdef::DM,PAM[]
 For more information about using REST API, see {URL_DEPLOYING_AND_MANAGING_SERVICES}#assembly-kie-apis[_{KIE_APIS}_].
 endif::DM,PAM[]

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
@@ -24,18 +24,18 @@ If you want to generate multiple projects in the same directory, you can specify
 +
 . Before creating the first asset, set a package for your business application, for example, `org.kie.businessapp`, and create respective directories in the following paths:
 +
-* `PROJECT_ROOT/src/main/java`
-* `PROJECT_ROOT/src/main/resources`
-* `PROJECT_ROOT/src/test/resources`
+* `PROJECT_HOME/src/main/java`
+* `PROJECT_HOME/src/main/resources`
+* `PROJECT_HOME/src/test/resources`
 
 +
-For example, you can create `PROJECT_ROOT/src/main/java/org/kie/businessapp`.
+For example, you can create `PROJECT_HOME/src/main/java/org/kie/businessapp` for `org.kie.businessapp` package.
 
-. Use VSCode to create assets for your business application using the following ways:
+. Use VSCode to create assets for your business application. You can create the assets supported by {PRODUCT} VSCode extension using the following ways:
 +
-* To create a business process, create a new file with `.bpmn` or `.bpmn2` in `PROJECT_ROOT/src/main/java/org/kie/businessapp` directory, such as `Process.bpmn`.
-* To create a DMN model, create a new file with `.dmn` in `PROJECT_ROOT/src/main/java/org/kie/businessapp` directory, such as `AgeDecision.dmn`.
-* To create a test scenario simulation model, create a new file with `.scesim` in `PROJECT_ROOT/src/main/java/org/kie/businessapp` directory, such as `TestAgeScenario.scesim`.
+* To create a business process, create a new file with `.bpmn` or `.bpmn2` in `PROJECT_HOME/src/main/java/org/kie/businessapp` directory, such as `Process.bpmn`.
+* To create a DMN model, create a new file with `.dmn` in `PROJECT_HOME/src/main/java/org/kie/businessapp` directory, such as `AgeDecision.dmn`.
+* To create a test scenario simulation model, create a new file with `.scesim` in `PROJECT_HOME/src/main/java/org/kie/businessapp` directory, such as `TestAgeScenario.scesim`.
 
 . After you create the assets in your Maven archetype, navigate to the root directory (contains `pom.xml`) of the project in the command line and run the following command to build the knowledge JAR (KJAR) of your project:
 +
@@ -44,8 +44,8 @@ For example, you can create `PROJECT_ROOT/src/main/java/org/kie/businessapp`.
 mvn clean install
 ----
 +
-If the build fails, address any problems described in the command line error messages and try again to validate the project until the build is successful. However, if the build is successful, you can find the artifact of your business application in `PROJECT_ROOT/target` directory.
+If the build fails, address any problems described in the command line error messages and try again to validate the project until the build is successful. However, if the build is successful, you can find the artifact of your business application in `PROJECT_HOME/target` directory.
 +
-NOTE: You must run `mvn clean install` command often to validate your project after each major change during development.
+NOTE: Use `mvn clean install` command often to validate your project after each major change during development.
 
 You can deploy the generated knowledge JAR (KJAR) of your business application on a running {KIE_SERVER} using the REST API. For more information about using REST API, see {URL_DEPLOYING_AND_MANAGING_SERVICES}#assembly-kie-apis[_{KIE_APIS}_].

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
@@ -7,28 +7,14 @@ You can use Maven archetypes to develop DMN and BPMN models in VSCode using the 
 . In a command terminal, navigate to a local folder where you want to store the new {PRODUCT} project.
 . Enter the following command to generate a project within a defined folder using the following Maven archetype:
 +
-ifdef::PAM,DM[]
 .Generating a project using Maven archetype
 [source,subs="attributes+"]
 ----
 mvn archetype:generate \
     -DarchetypeGroupId=org.kie \
     -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion={ENTERPRISE_VERSION_LONG}
+    -DarchetypeVersion={MAVEN_ARTIFACT_VERSION}
 ----
-endif::PAM,DM[]
-
-ifdef::DROOLS,JBPM,OP[]
-.Generating a project using Maven archetype
-[source,subs="attributes+"]
-----
-mvn archetype:generate \
-    -DarchetypeGroupId=org.kie \
-    -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion={COMMUNITY_VERSION_LONG}
-----
-endif::DROOLS,JBPM,OP[]
-
 +
 This command generates a Maven project with required dependencies and generates required directories and files to build your business application. You can set up and use Git version-control system (recommended) when developing a project.
 +
@@ -36,24 +22,30 @@ If you want to generate multiple projects in the same directory, you can specify
 
 . In your VSCode IDE, click *File*, select *Open Folder*, and navigate to the folder that is generated using the previous command.
 +
-. Before creating the first asset, set a package for your business application, for example, `org.kie.businessapp`.
-. Create a Java object in `src/main/java/` directory, for example, `/src/main/java/org/kie/businessapp/DataObject.java`.
-. Create your business process or business rules in `src/main/resources` directory, for example, `/src/main/resources/org/kie/businessapp/Process.bpmn`.
+. Before creating the first asset, set a package for your business application, for example, `org.kie.businessapp`, and create respective directories in the following paths:
++
+* `PROJECT_ROOT/src/main/java`
+* `PROJECT_ROOT/src/main/resources`
+* `PROJECT_ROOT/src/test/resources`
 
 +
-You can use VSCode to create files and folders as per your requirement.
+For example, you can create `PROJECT_ROOT/src/main/java/org/kie/businessapp`.
 
-. After you create the assets in your Maven archetype, navigate to the project directory (contains `pom.xml`) in the command line and run the following command to build your files:
+. Use VSCode to create assets for your business application using the following ways:
 +
-.Building Maven project
+* To create a business process, create a new file with `.bpmn` or `.bpmn2` in `PROJECT_ROOT/src/main/java/org/kie/businessapp` directory, such as `Process.bpmn`.
+* To create a DMN model, create a new file with `.dmn` in `PROJECT_ROOT/src/main/java/org/kie/businessapp` directory, such as `AgeDecision.dmn`.
+* To create a test scenario simulation model, create a new file with `.scesim` in `PROJECT_ROOT/src/main/java/org/kie/businessapp` directory, such as `TestAgeScenario.scesim`.
+
+. After you create the assets in your Maven archetype, navigate to the root directory (contains `pom.xml`) of the project in the command line and run the following command to build the knowledge JAR (KJAR) of your project:
++
 [source]
 ----
 mvn clean install
 ----
 +
-If the build fails, address any problems described in the command line error messages and try again to validate the project until the build is successful.
+If the build fails, address any problems described in the command line error messages and try again to validate the project until the build is successful. However, if the build is successful, you can find the artifact of your business application in `PROJECT_ROOT/target` directory.
 +
-After the build is successful, you can deploy the generated knowledge JAR (KJAR) of your business application on a running {KIE_SERVER} using the REST API.
-ifdef::DM,PAM[]
-For more information about using REST API, see {URL_DEPLOYING_AND_MANAGING_SERVICES}#assembly-kie-apis[_{KIE_APIS}_].
-endif::DM,PAM[]
+NOTE: You must run `mvn clean install` command often to validate your project after each major change during development.
+
+You can deploy the generated knowledge JAR (KJAR) of your business application on a running {KIE_SERVER} using the REST API. For more information about using REST API, see {URL_DEPLOYING_AND_MANAGING_SERVICES}#assembly-kie-apis[_{KIE_APIS}_].

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-dmn-bpmn-maven-create.adoc
@@ -9,23 +9,23 @@ You can use Maven archetypes to develop DMN and BPMN models and integrate the ar
 +
 ifdef::PAM,DM[]
 .Generating a project using Maven archetype
-[source]
+[source,subs="attributes+"]
 ----
 mvn archetype:generate \
     -DarchetypeGroupId=org.kie \
     -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion={rhpam.version}-SNAPSHOT
+    -DarchetypeVersion={ENTERPRISE_VERSION_LONG}-SNAPSHOT
 ----
 endif::PAM,DM[]
 
 ifdef::DROOLS,JBPM,OP[]
 .Generating a project using Maven archetype
-[source]
+[source,subs="attributes+"]
 ----
 mvn archetype:generate \
     -DarchetypeGroupId=org.kie \
     -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion={drools.version}-SNAPSHOT
+    -DarchetypeVersion={COMMUNITY_VERSION_LONG}-SNAPSHOT
 ----
 endif::DROOLS,JBPM,OP[]
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
@@ -3,7 +3,7 @@
 
 {PRODUCT} provides a *Red Hat Business Automation Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
-IMPORTANT: The VSCode extension is a client-side editor that is partially compatible with the {CENTRAL} features. The features such as importing projects from {CENTRAL} are not supported in the VSCode. If you want to use such features in the VSCode, you can raise a request for a required feature. 
+IMPORTANT: The editors in the VSCode extension are only partially compatible with the editors in the {CENTRAL}, and several {CENTRAL} features are not supported. The VSCode extension is recommended for building new projects.
 
 .Prerequisites
 * https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
@@ -20,3 +20,13 @@ After you install the VSCode extension bundle, any `.dmn`, `.bpmn`, or `.bpmn2` 
 If the DMN, BPMN, or test scenario modelers open only the XML source of a DMN, BPMN, or test scenario file and displays an error message, review the reported errors and the model file to ensure that all elements are correctly defined.
 
 NOTE: For new DMN or BPMN models, you can also enter `dmn.new` or `bpmn.new` in a web browser to design your DMN or BPMN model in the online modeler. When you finish creating your model, you can click *Download* in the online modeler page to import your DMN or BPMN file into your {PRODUCT} project in VSCode.
+
+Before you can begin developing BPMN and DMN models in VSCode, you need to create a Maven project where you can build your assets and any other related resources for your application. To generate a Maven project using the default Maven archetype, navigate to a local folder and enter the following command in the command terminal:
+
+[source]
+----
+mvn archetype:generate \
+    -DarchetypeGroupId=org.kie \
+    -DarchetypeArtifactId=kie-kjar-archetype \
+    -DarchetypeVersion=7.45.0-SNAPSHOT
+----

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
@@ -6,7 +6,7 @@
 IMPORTANT: The editors in the VSCode are partially compatible with the editors in the {CENTRAL}, and several {CENTRAL} features are not supported in the VSCode.
 
 .Prerequisites
-* Latest stable version of https://code.visualstudio.com/[VSCode] is installed.
+* The latest stable version of https://code.visualstudio.com/[VSCode] is installed.
 
 .Procedure
 . In your VSCode IDE, select the *Extensions* menu option and search for *Red Hat Business Automation Bundle* for DMN, BPMN, and test scenario file support.
@@ -20,5 +20,3 @@ After you install the VSCode extension bundle, any `.dmn`, `.bpmn`, or `.bpmn2` 
 If the DMN, BPMN, or test scenario modelers open only the XML source of a DMN, BPMN, or test scenario file and displays an error message, review the reported errors and the model file to ensure that all elements are correctly defined.
 
 NOTE: For new DMN or BPMN models, you can also enter `dmn.new` or `bpmn.new` in a web browser to design your DMN or BPMN model in the online modeler. When you finish creating your model, you can click *Download* in the online modeler page to import your DMN or BPMN file into your {PRODUCT} project in VSCode.
-
-Before you can begin developing BPMN and DMN models in VSCode, you need to create a Maven project where you can build your assets and any other related resources for your application. For more information about creating Maven project, see {URL_GETTING_STARTED}[Getting started with {PRODUCT}].

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
@@ -3,7 +3,7 @@
 
 {PRODUCT} provides a *Red Hat Business Automation Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
-IMPORTANT: The VSCode extension is a client-side editor that is partially compatible with the {CENTRAL} features. The features such as importing projects from {CENTRAL} are not supported in the VSCode. If you want to use such features in the VSCode, you can request for the required features. 
+IMPORTANT: The VSCode extension is a client-side editor that is partially compatible with the {CENTRAL} features. The features such as importing projects from {CENTRAL} are not supported in the VSCode. If you want to use such features in the VSCode, you can raise a request for a required feature. 
 
 .Prerequisites
 * https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
@@ -3,6 +3,8 @@
 
 {PRODUCT} provides a *Red Hat Business Automation Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
+IMPORTANT: The VSCode extension is a client-side editor that is partially compatible with the {CENTRAL} features. The features such as importing projects from {CENTRAL} are not supported in the VSCode. If you want to use such features in the VSCode, you can request for the required features. 
+
 .Prerequisites
 * https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
 

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
@@ -1,12 +1,12 @@
 [id="proc-vscode-extension_{context}"]
 = Installing the {PRODUCT} VSCode extension bundle
 
-{PRODUCT} provides a *Red Hat Business Automation Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
+{PRODUCT} provides a *Red Hat Business Automation Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. VSCode is the preferred integrated development environment (IDE) for developing new business applications. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
-IMPORTANT: The editors in the VSCode extension are only partially compatible with the editors in the {CENTRAL}, and several {CENTRAL} features are not supported. The VSCode extension is recommended for building new projects.
+IMPORTANT: The editors in the VSCode extension are only partially compatible with the editors in the {CENTRAL}, and several {CENTRAL} features are not supported. If you want to use such features in the VSCode, you can raise a request for a required feature.
 
 .Prerequisites
-* https://code.visualstudio.com/[VSCode] 1.46.0 or later is installed.
+* Latest stable version of https://code.visualstudio.com/[VSCode] is installed.
 
 .Procedure
 . In your VSCode IDE, select the *Extensions* menu option and search for *Red Hat Business Automation Bundle* for DMN, BPMN, and test scenario file support.
@@ -15,18 +15,10 @@ For DMN or BPMN file support only, you can also search for the individual *DMN E
 . When the *Red Hat Business Automation Bundle* extension appears in VSCode, select it and click *Install*.
 . For optimal VSCode editor behavior, after the extension installation is complete, reload or close and re-launch your instance of VSCode.
 
-After you install the VSCode extension bundle, any `.dmn`, `.bpmn`, or `.bpmn2` files that you open in VSCode are automatically displayed as graphical models. Additionally, any `.scesim` files that you open are automatically displayed as tabular test scenario models for testing the functionality of your business decisions.
+After you install the VSCode extension bundle, any `.dmn`, `.bpmn`, or `.bpmn2` files that you open or create in VSCode are automatically displayed as graphical models. Additionally, any `.scesim` files that you open or create are automatically displayed as tabular test scenario models for testing the functionality of your business decisions.
 
 If the DMN, BPMN, or test scenario modelers open only the XML source of a DMN, BPMN, or test scenario file and displays an error message, review the reported errors and the model file to ensure that all elements are correctly defined.
 
 NOTE: For new DMN or BPMN models, you can also enter `dmn.new` or `bpmn.new` in a web browser to design your DMN or BPMN model in the online modeler. When you finish creating your model, you can click *Download* in the online modeler page to import your DMN or BPMN file into your {PRODUCT} project in VSCode.
 
-Before you can begin developing BPMN and DMN models in VSCode, you need to create a Maven project where you can build your assets and any other related resources for your application. To generate a Maven project using the default Maven archetype, navigate to a local folder and enter the following command in the command terminal:
-
-[source]
-----
-mvn archetype:generate \
-    -DarchetypeGroupId=org.kie \
-    -DarchetypeArtifactId=kie-kjar-archetype \
-    -DarchetypeVersion=7.45.0-SNAPSHOT
-----
+Before you can begin developing BPMN and DMN models in VSCode, you need to create a Maven project where you can build your assets and any other related resources for your application. For more information about creating Maven project, see {URL_GETTING_STARTED}[Getting started with {PRODUCT}].

--- a/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
+++ b/doc-content/shared-kie-docs/src/main/asciidoc/Install/proc-vscode-extension.adoc
@@ -3,7 +3,7 @@
 
 {PRODUCT} provides a *Red Hat Business Automation Bundle* VSCode extension that enables you to design Decision Model and Notation (DMN) decision models, Business Process Model and Notation (BPMN) 2.0 business processes, and test scenarios directly in VSCode. VSCode is the preferred integrated development environment (IDE) for developing new business applications. {PRODUCT} also provides individual *DMN Editor* and *BPMN Editor* VSCode extensions for DMN or BPMN support only, if needed.
 
-IMPORTANT: The editors in the VSCode extension are only partially compatible with the editors in the {CENTRAL}, and several {CENTRAL} features are not supported. If you want to use such features in the VSCode, you can raise a request for a required feature.
+IMPORTANT: The editors in the VSCode are partially compatible with the editors in the {CENTRAL}, and several {CENTRAL} features are not supported in the VSCode.
 
 .Prerequisites
 * Latest stable version of https://code.visualstudio.com/[VSCode] is installed.


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-7136

**Enterprise**
**Developing Process Services in RHPAM/RHDM** -

- Added a note and reference of Maven project procedure in [2.1. Installing the Red Hat Process Automation Manager VSCode Extension Bundle](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7136-BPMN-RHPAM/#proc-vscode-extension_business-processes).
- Added new chapter as [CHAPTER 3. Creating and Executing DMN and BPMN Models Using Maven](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7136-BPMN-RHPAM/#proc-dmn-bpmn-maven-create_business-processes)



**Developing Decision Services in RHPAM/RHDM**

- Added a note and reference of Maven project procedure in [2.1. Installing the Red Hat Process Automation Manager VSCode Extension Bundle](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7136-DMN-RHPAM/#proc-vscode-extension_dmn-models).
- Added new chapter as [CHAPTER 3. Creating and Executing DMN and BPMN Models Using Maven](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7136-DMN-RHPAM/#proc-dmn-bpmn-maven-create_dmn-models)

**Getting started guides**
Added new section as **CHAPTER 3. Creating and Executing DMN and BPMN Models Using Maven** in the following getting started documents:

Doc previews:
[Getting started with decision services in Red Hat Process Automation Manager](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7136-GS-RHPAM/#proc-dmn-bpmn-maven-create_getting-started-decision-services)
[Getting started with process services in Red Hat Process Automation Manager](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7136-GS-RHPAM/#proc-dmn-bpmn-maven-create_getting-started-process-services)