### PR TITLE
WIP BXMSDOC-7484: Updated PMML doc as per BAPL-1845

### DIFF
--- a/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-included-models-pmml-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/DMN/dmn-included-models-pmml-proc.adoc
@@ -17,12 +17,12 @@ You cannot include PMML models from other projects in {CENTRAL}.
 <!-- Required for the PMML compiler -->
 <dependency>
   <groupId>org.drools</groupId>
-  <artifactId>kie-pmml</artifactId>
+  <artifactId>kie-pmml-trusty</artifactId>
   <version>${{PRODUCT_INIT}.version}</version>
   <scope>provided</scope>
 </dependency>
 
-<!-- Alternative dependencies for JPMML Evaluator, override `kie-pmml` dependency -->
+<!-- Alternative dependencies for JPMML Evaluator, override `kie-pmml` and `kie-pmml-trusty` dependency -->
 <dependency>
   <groupId>org.kie</groupId>
   <artifactId>kie-dmn-jpmml</artifactId>
@@ -45,7 +45,7 @@ You cannot include PMML models from other projects in {CENTRAL}.
 
 To access the project `pom.xml` file in {CENTRAL}, you can select any existing asset in the project and then in the *Project Explorer* menu on the left side of the screen, click the *Customize View* gear icon and select *Repository View* -> *pom.xml*.
 
-If you want to use the full PMML specification implementation with the Java Evaluator API for PMML (JPMML), use the alternative set of JPMML dependencies in your DMN project. If the JPMML dependencies and the standard `kie-pmml` dependency are both present, the `kie-pmml` dependency is disabled. For information about JPMML licensing terms, see https://openscoring.io/[Openscoring.io].
+If you want to use the full PMML specification implementation with the Java Evaluator API for PMML (JPMML), use the alternative set of JPMML dependencies in your DMN project. If the JPMML dependencies, the standard `kie-pmml`, and `kie-pmml-trusty` dependency are present, the `kie-pmml` and `kie-pmml-trusty` dependency are disabled. For information about JPMML licensing terms, see https://openscoring.io/[Openscoring.io].
 
 ifdef::DM,PAM[]
 [IMPORTANT]

--- a/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-embedded-proc.adoc
+++ b/doc-content/drools-docs/src/main/asciidoc/PMML/pmml-invocation-embedded-proc.adoc
@@ -23,7 +23,7 @@ endif::[]
 <!-- Required for the PMML compiler -->
 <dependency>
   <groupId>org.drools</groupId>
-  <artifactId>kie-pmml</artifactId>
+  <artifactId>kie-pmml-trusty</artifactId>
   <version>${{PRODUCT_INIT}.version}</version>
 </dependency>
 


### PR DESCRIPTION
See JIRA: https://issues.redhat.com/browse/BXMSDOC-7484
Epic: https://issues.redhat.com/browse/BXMSDOC-7299
Impacted BAPL: [BAPL-1845](https://issues.redhat.com/browse/BAPL-1845)

Added kie-pmml-trusty as a dependency in following sections:
6.3.2. Including PMML models within a DMN file in Business Central
13.1. Embedding a PMML call directly in a Java Application

Doc previews:
Enterprise
RHPAM
[6.3.2. Including PMML models within a DMN file in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7484-RHPAM/#dmn-included-models-pmml-proc_dmn-models)
[13.1. Embedding a PMML call directly in a Java Application](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7484-RHPAM/#pmml-invocation-embedded-proc_pmml-models)

RHDM
[6.3.2. Including PMML models within a DMN file in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7484-RHDM/#dmn-included-models-pmml-proc_dmn-models)
[13.1. Embedding a PMML call directly in a Java Application](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7484-RHDM/#pmml-invocation-embedded-proc_pmml-models)

Community
Drools
[6.3.3.2. Including PMML models within a DMN file in Business Central](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7484-DROOLS/#dmn-included-models-pmml-proc_dmn-models)
[7.4.1. Embedding a PMML call directly in a Java application](http://file.pnq.redhat.com/~hmanwani/BXMSDOC-7484-DROOLS/#pmml-invocation-embedded-proc_pmml-models)

